### PR TITLE
Optimize z_stream internal buffer allocations

### DIFF
--- a/src/knn.c
+++ b/src/knn.c
@@ -141,7 +141,7 @@ typedef struct {
 
 void klass_predictor_init(Klass_Predictor *kp, Samples train_samples)
 {
-    kp->nprocs = get_nproc();
+    kp->nprocs = get_nprocs();
     kp->chunk_size = train_samples.count/kp->nprocs;
     kp->chunk_rem = train_samples.count%kp->nprocs;
     kp->train_samples = train_samples;

--- a/src/knn.c
+++ b/src/knn.c
@@ -23,7 +23,7 @@ Nob_String_View deflate_sv(Arena *arena, Nob_String_View sv)
     defstream.avail_out = (uInt)output_size;
     defstream.next_out = (Bytef *)output;
 
-    deflateInit(&defstream, Z_BEST_COMPRESSION);
+    assert(deflateInit(&defstream, Z_BEST_COMPRESSION) == Z_OK, "Failed to initialize zlib deflate stream");
     int result = deflate(&defstream, Z_FINISH);
     assert(result == Z_STREAM_END && "Probably not enough output buffer was allocated");
     deflateEnd(&defstream);

--- a/src/knn.c
+++ b/src/knn.c
@@ -11,23 +11,30 @@
 
 #define K 2
 
+static __thread z_stream defstream = {0};
+static __thread bool defstream_init = false;
+
 // Stolen from https://gist.github.com/arq5x/5315739
 Nob_String_View deflate_sv(Arena *arena, Nob_String_View sv)
 {
-    z_stream defstream = {0};
     defstream.avail_in = (uInt)sv.count;
     defstream.next_in = (Bytef *)sv.data;
 
-    assert(deflateInit(&defstream, Z_BEST_COMPRESSION) == Z_OK, "Failed to initialize zlib deflate stream");
+    int ret = defstream_init ? deflateReset(&defstream) : deflateInit(&defstream, Z_BEST_COMPRESSION);
+    defstream_init = true;
+    assert(ret == Z_OK && "Failed to initialize zlib deflate stream");
     size_t output_size = (size_t)deflateBound(&defstream, defstream.avail_in);
     void *output = arena_alloc(arena, output_size);
     defstream.avail_out = (uInt)output_size;
     defstream.next_out = (Bytef *)output;
 
     assert(deflate(&defstream, Z_FINISH) == Z_STREAM_END && "Probably `avail_in` is zero");
-    deflateEnd(&defstream);
 
     return nob_sv_from_parts(output, defstream.total_out);
+}
+
+void deflate_end() {
+    deflateEnd(&defstream);
 }
 
 typedef struct {
@@ -114,6 +121,7 @@ void *klassify_thread(void *params)
             .klass = state->train[i].klass,
         }));
     }
+    deflate_end();
 
     return NULL;
 }
@@ -133,7 +141,7 @@ typedef struct {
 
 void klass_predictor_init(Klass_Predictor *kp, Samples train_samples)
 {
-    kp->nprocs = get_nprocs();
+    kp->nprocs = get_nproc();
     kp->chunk_size = train_samples.count/kp->nprocs;
     kp->chunk_rem = train_samples.count%kp->nprocs;
     kp->train_samples = train_samples;


### PR DESCRIPTION
This pull request gets rid of "Probably not enough output buffer was allocated" error and redundant allocations of zlib internal buffers.

The idea is to minimize redundant (de-)allocation amount of the zlib internal buffers. Although the madler zlib claims to be thread-safe as long as the allocator passed as zalloc is, this commit carries a thread local static z_stream. It also requires us to manually end the stream: function `deflate_end` introduced.
Reference: [zlib manual](https://www.zlib.net/manual.html)

In fact, this optimization can be pushed just a bit further. Currently, deflate stream is reinitialized on every `klass_predictor_predict` call, but could be initialized once per every thread.

Additionally, I wanted to check some SIMD-accelerated implementations of ZLIB, which includes: [zlib-chromium](https://chromium.googlesource.com/chromium/src/third_party/zlib), [zlib-ng](https://github.com/zlib-ng/zlib-ng), [zlib-cloudflare](https://github.com/cloudflare/zlib) and [!][zlib-intel](https://github.com/intel/zlib).

Mentioned repos are under the zlib license.

Also it would be nice to check out [libdeflate]([text](https://github.com/ebiggers/libdeflate)). It doesn't include gzip headers, nor checksums and claimed to be ~33% faster than zlib-cloudflare by some benchmarks (Haven't tested myself though).

All benchmarks below were intentionally tested on a single thread.
Every library from the list have been compiled using the default branch.
Benchmarks using ag-news dataset: ./nob; ./build/knn ./data/ag-news/classes.csv ./data/ag-news/test.csv
CPU: i7-12700F, 2100 Mhz
RAM: 32GB DDR5-5200 MT/s XMP 3.0
HDD: Seq 64 127 MB/s

Commit 52e1d9eaaf2c01cd98516c335c8fa4dcb6d5b12d:
  > Success rate: 79/100 (0.790000)
  > Total Elapsed: 271.484s
  > Avg Elapsed: 2.71484

z_stream optimization (from now on will be referred to as "zs opt"):
  > Success rate: 79/100 (0.790000)
  > Total Elapsed: 264.248s
  > Avg Elapsed: 2.64248s

zs opt + zlib-ng
  > Success rate: 79/100 (0.790000)
  > Total Elapsed: 282.062s
  > Avg Elapsed: 2.82062s

zs opt + zlib-chromium:
  > Success rate: 79/100 (0.790000)
  > Total Elapsed: 263.481s
  > Avg Elapsed: 2.63481s

zs opt + zlib-intel:
  > Success rate: 79/100 (0.790000)
  > Total Elapsed: 261.152s
  > Avg Elapsed: 2.61152s

zs opt + zlib-cloudflare:
  > Success rate: 78/100 (0.780000)
  > Total Elapsed: 224.895s
  > Avg Elapsed: 2.24895s

---

Open for discussions 

**P.S.**
After some research, libdeflate seems to work well: Success rate has increased to 82% for the same dataset, avg elapsed time decreased to 1.96734s (Tested with K = 2 and compression level set to 9). In the end the speed has risen by ~28% compared to the original `deflate_sv`.
The increase in the success rate makes sense, since zlib and gzip headers are putting some format-specific headers, which potentially might add inaccuracy to the classification.